### PR TITLE
Refactor tests for address association with users and orders

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,6 +1,5 @@
 class AddressesController < ApplicationController
   def new
-    # @address = Address.new
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,6 @@ class UsersController < ApplicationController
 
   def update_profile
     if current_user.update(update_profile_params)
-      current_user.addresses.where(alias: 'Home').update(upadate_address_params)
       flash[:success] = 'Your profile data has been updated!'
       redirect_to profile_path
     else

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -10,7 +10,7 @@ class Merchant < ApplicationRecord
                         :city,
                         :state,
                         :zip
-  
+
   validates_inclusion_of :enabled?, in: [true, false]
 
   def no_orders?
@@ -26,9 +26,9 @@ class Merchant < ApplicationRecord
   end
 
   def distinct_cities
-    item_orders.distinct.joins(order: :user)
+    item_orders.distinct.joins(order: [:user, :address])
       .where('"users"."enabled?" = \'t\'')
-      .pluck('orders.city')
+      .pluck('addresses.city')
   end
 
   def specific_orders

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -2,10 +2,6 @@
   <%=
     render partial: 'partials/user_info', locals: {
       name: @user.name,
-      address: @user.address,
-      city: @user.city,
-      state: @user.state,
-      zip: @user.zip,
       email: @user.email
     }
   %>

--- a/app/views/merchant/orders/show.html.erb
+++ b/app/views/merchant/orders/show.html.erb
@@ -10,10 +10,10 @@
     </tr>
     <tr>
       <td><p><%= @order.name %> </p></td>
-      <td><p><%= @order.address %> </p></td>
-      <td><p><%= @order.city %> </p></td>
-      <td><p><%= @order.state %> </p></td>
-      <td><p><%= @order.zip %> </p></td>
+      <td><p><%= @order.address.address %> </p></td>
+      <td><p><%= @order.address.city %> </p></td>
+      <td><p><%= @order.address.state %> </p></td>
+      <td><p><%= @order.address.zip %> </p></td>
     </tr>
   </table>
 </section>

--- a/app/views/partials/_user_form_template.html.erb
+++ b/app/views/partials/_user_form_template.html.erb
@@ -1,6 +1,2 @@
 <p>Name: <%= text_field_tag :name, name %></p>
-<p>Address: <%= text_field_tag :address, address %></p>
-<p>City: <%= text_field_tag :city, city %></p>
-<p>State: <%= text_field_tag :state, state %></p>
-<p>Zip: <%= text_field_tag :zip, zip %></p>
 <p>Email: <%= text_field_tag :email, email%></p>

--- a/app/views/partials/_user_info.html.erb
+++ b/app/views/partials/_user_info.html.erb
@@ -1,8 +1,4 @@
 <p>Name: <%= name %></p>
-<p>Address: <%= address %></p>
-<p>City: <%= city %></p>
-<p>State: <%= state %></p>
-<p>Zip: <%= zip %></p>
 <% if email %>
   <p>Email: <%= email %></p>
 <% end %>

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -2,10 +2,6 @@
   <%=
     render partial: 'partials/user_form_template', locals: {
       name: current_user.name,
-      address: current_user.address,
-      city: current_user.city,
-      state: current_user.state,
-      zip: current_user.zip,
       email: current_user.email
     }
   %>

--- a/spec/features/admin/user_orders/show_spec.rb
+++ b/spec/features/admin/user_orders/show_spec.rb
@@ -2,17 +2,19 @@ require 'rails_helper'
 
 RSpec.describe 'As an Admin User' do
   describe 'when I visit a user\'s profile' do
-    it 'I can click a link and view the user\'s order show page' do
-      user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+    xit 'I can click a link and view the user\'s order show page' do
+      user_1 = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
+      address_1 = user_1.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
       dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
       tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
       pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
-      order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 2)
+      order_1 = user_1.orders.create(name: 'User 1', address_id: address_1.id, status: 2)
       item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id)
       item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id)
 
-      site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+      site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
+      site_admin.addresses.create(address: '123 First', city: 'Denver', state: 'CO', zip: 80_233)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
 
@@ -53,16 +55,19 @@ RSpec.describe 'As an Admin User' do
 
     describe 'then click a link to visit a user\'s order show page' do
       it 'it displays a link to cancel an order that is Pending' do
-        user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+        user_1 = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
+        address_1 = user_1.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
         dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
         bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
         tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
         pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
-        order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 0)
+        order_1 = user_1.orders.create(name: 'User 1', address_id: address_1.id, status: 0)
+
         item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id, status: 1)
         item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id, status: 0)
 
-        site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+        site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
+        site_admin.addresses.create(address: '123 First', city: 'Denver', state: 'CO', zip: 80_233)
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
 
@@ -88,16 +93,19 @@ RSpec.describe 'As an Admin User' do
       end
 
       it 'it does not display a link to cancel an order that is Packaged' do
-        user_1 = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
+        user_1 = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
+        address_1 = user_1.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
         dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
         bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
         tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
         pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
-        order_1 = user_1.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 1)
+        order_1 = user_1.orders.create(name: 'User 1', address_id: address_1.id, status: 1)
+
         item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id, status: 1)
         item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id, status: 1)
 
-        site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+        site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
+        site_admin.addresses.create(address: '123 First', city: 'Denver', state: 'CO', zip: 80_233)
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
 

--- a/spec/features/admin/user_orders/show_spec.rb
+++ b/spec/features/admin/user_orders/show_spec.rb
@@ -2,36 +2,36 @@ require 'rails_helper'
 
 RSpec.describe 'As an Admin User' do
   describe 'when I visit a user\'s profile' do
-    xit 'I can click a link and view the user\'s order show page' do
-      user_1 = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
-      address_1 = user_1.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+    it 'I can click a link and view the user\'s order show page' do
+      user = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
+      address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
       dog_shop = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80_210)
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '125 Bike St.', city: 'Denver', state: 'CO', zip: 80_210)
       tire = bike_shop.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
       pull_toy = dog_shop.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
-      order_1 = user_1.orders.create(name: 'User 1', address_id: address_1.id, status: 2)
-      item_order_1 = order_1.item_orders.create(order_id: order_1.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id)
-      item_order_2 = order_1.item_orders.create(order_id: order_1.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id)
+      order = user.orders.create(name: 'User 1', address_id: address.id, status: 2)
+      item_order_1 = order.item_orders.create(order_id: order.id, item_id: tire.id, quantity: 2, price: 15, merchant_id: bike_shop.id)
+      item_order_2 = order.item_orders.create(order_id: order.id, item_id: pull_toy.id, quantity: 1, price: 100, merchant_id: dog_shop.id)
 
       site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
       site_admin.addresses.create(address: '123 First', city: 'Denver', state: 'CO', zip: 80_233)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(site_admin)
 
-      visit "/admin/users/#{user_1.id}"
+      visit "/admin/users/#{user.id}"
 
       within '#user-order-links' do
-        click_on "#{order_1.id}"
+        click_on "#{order.id}"
       end
 
-      expect(current_path).to eq(admin_user_order_path(user_1.id, order_1.id))
+      expect(current_path).to eq(admin_user_order_path(user.id, order.id))
 
       within '#order-info' do
-        expect(page).to have_content("Date Created: #{order_1.created_at}")
-        expect(page).to have_content("Last Updated: #{order_1.updated_at}")
-        expect(page).to have_content("Status: #{order_1.status}")
-        expect(page).to have_content("Total Quantity: #{order_1.total_quantity}")
-        expect(page).to have_content("Grand Total: $#{order_1.grand_total}")
+        expect(page).to have_content("Date Created: #{order.created_at}")
+        expect(page).to have_content("Last Updated: #{order.updated_at}")
+        expect(page).to have_content("Status: #{order.status}")
+        expect(page).to have_content("Total Quantity: #{order.total_quantity}")
+        expect(page).to have_content("Grand Total: $#{order.grand_total}")
       end
 
       within "#item-order-#{item_order_1.id}" do

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -3,25 +3,10 @@ require 'rails_helper'
 RSpec.describe 'As an admin user' do
   describe 'when I visit a user\'s profile page' do
     before(:each) do
-      @user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      @user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
+      address = @user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
-      @site_admin = User.create(
-        name: 'Site Admin',
-        address: '123 First',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'site_admin@user.com',
-        password: 'secure',
-        role: 3)
+      @site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
     end

--- a/spec/features/items/destroy_spec.rb
+++ b/spec/features/items/destroy_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe 'item delete', type: :feature do
       end
 
       it 'it cannot delete items with orders' do
-        user = User.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user@email.com', password: 'secure')
-        order_1 = user.orders.create!(name: 'Meg', address: '123 Stang St', city: 'Hershey', state: 'PA', zip: 80_218)
+        user = User.create(name: 'Bob', email: 'user@email.com', password: 'secure')
+        address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+        order_1 = user.orders.create!(name: 'Meg', address_id: address.id)
         order_1.item_orders.create!(item: @chain, price: @chain.price, quantity: 2)
 
         visit "/items/#{@chain.id}"

--- a/spec/features/items/stats_spec.rb
+++ b/spec/features/items/stats_spec.rb
@@ -14,15 +14,10 @@ describe 'Items Index Page' do
       @lock = meg.items.create(name: 'Lock', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
       @seat = meg.items.create(name: 'Seat', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
 
-      user = User.create!(name: 'Bob',
-                          address: '123 Main',
-                          city: 'Denver',
-                          state: 'CO',
-                          zip: 80_233,
-                          email: 'bob@email.com',
-                          password: 'secure')
+      user = User.create!(name: 'Bob', email: 'bob@email.com', password: 'secure')
+      address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
-      order = user.orders.create(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+      order = user.orders.create(name: 'Bob', address_id: address.id)
 
       ItemOrder.create(order_id: order.id, item_id: @tire.id, quantity: 12, price: 100)
       ItemOrder.create(order_id: order.id, item_id: @pump.id, quantity: 3, price: 20)

--- a/spec/features/merchant/merchant_dash_spec.rb
+++ b/spec/features/merchant/merchant_dash_spec.rb
@@ -31,18 +31,11 @@ describe 'As a logged in Merchant (employee/admin)' do
   end
 
   it 'I see a list of pending orders with items I sell' do
-    user = User.create!(
-      name: 'User_bob',
-      address: '123 Main',
-      city: 'Denver',
-      state: 'CO',
-      zip: 80_233,
-      email: 'user@email.com',
-      password: 'secure'
-    )
+    user = User.create!( name: 'User_bob', email: 'user@email.com', password: 'secure')
+    address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
-    order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
-    order_2 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033, status: 'Pending')
+    order_1 = user.orders.create!(name: 'Meg', address_id: address.id, status: 'Pending')
+    order_2 = user.orders.create!(name: 'Meg', address_id: address.id, status: 'Pending')
 
     order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
     order_1.item_orders.create!(item: @helmet, price: @helmet.price, quantity: 2)

--- a/spec/features/merchant/merchant_orders_spec.rb
+++ b/spec/features/merchant/merchant_orders_spec.rb
@@ -12,30 +12,14 @@ describe 'As a logged in Merchant (employee/admin)' do
     @paper = @mike.items.create(name: 'Lined Paper', description: 'Great for writing on!', price: 20, image: 'https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png', inventory: 3)
     @pencil = @mike.items.create(name: 'Yellow Pencil', description: 'You can write on paper with it!', price: 2, image: 'https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg', inventory: 100)
 
-    @merchant_employee = @meg.users.create!(
-      name: 'Other Bob',
-      address: '123 Bike Rd.',
-      city: 'Denver',
-      state: 'CO',
-      zip: 80_203,
-      email: 'otherbob@email.com',
-      password: 'secure',
-      role: 1
-    )
+    @merchant_employee = @meg.users.create!(name: 'Other Bob', email: 'otherbob@email.com', password: 'secure', role: 1)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_employee)
 
-    @user = User.create!(
-      name: 'Bob',
-      address: '123 Main',
-      city: 'Denver',
-      state: 'CO',
-      zip: 80_233,
-      email: '@user@email.com',
-      password: 'secure'
-    )
+    @user = User.create!(name: 'Bob', email: '@user@email.com', password: 'secure')
+    address = @user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
-    @order = @user.orders.create!(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 'Pending')
+    @order = @user.orders.create!(name: 'Bob', address_id: address.id, status: 'Pending')
 
     ItemOrder.create!(order_id: @order.id, item_id: @tire.id, quantity: 3, price: 100, merchant_id: @meg.id)
     ItemOrder.create!(order_id: @order.id, item_id: @pump.id, quantity: 4, price: 25, merchant_id: @meg.id)
@@ -48,11 +32,11 @@ describe 'As a logged in Merchant (employee/admin)' do
   it 'I only see the items in the order that are being purchased from my merchant' do
     expect(current_path).to eq("/merchant/orders/#{@order.id}")
 
-    expect(page).to have_content(@user.name)
-    expect(page).to have_content(@user.address)
-    expect(page).to have_content(@user.city)
-    expect(page).to have_content(@user.state)
-    expect(page).to have_content(@user.zip)
+    expect(page).to have_content(@order.name)
+    expect(page).to have_content(@order.address.address)
+    expect(page).to have_content(@order.address.city)
+    expect(page).to have_content(@order.address.state)
+    expect(page).to have_content(@order.address.zip)
 
     within "#item-#{@pump.id}" do
       expect(page).to have_content(@pump.name)

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'As an admin user' do
   describe 'When I visit a merchant show page' do
     before(:each) do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80_203)
-      @site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
+      @site_admin = User.create(name: 'Site Admin', email: 'site_admin@user.com', password: 'secure', role: 3)
       @chain = @bike_shop.items.create(name: 'Chain', description: "It'll never break!", price: 50, image: 'https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588', inventory: 5)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
@@ -29,15 +29,13 @@ RSpec.describe 'As an admin user' do
     end
 
     it "I can't delete a merchant that has orders" do
-      user = User.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, email: 'user_1@user.com', password: 'secure', role: 0)
-      order = user.orders.create(name: 'User 1', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 2)
+      user = User.create(name: 'User 1', email: 'user_1@user.com', password: 'secure', role: 0)
+      address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+      order = user.orders.create(name: 'User 1', address_id: address.id, status: 2)
       item_order = order.item_orders.create(order_id: order.id, item_id: @chain.id, quantity: 1, price: 50, merchant_id: @bike_shop.id)
 
-      @site_admin = User.create(name: 'Site Admin', address: '123 First', city: 'Denver', state: 'CO', zip: 80_233, email: 'site_admin@user.com', password: 'secure', role: 3)
-
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@site_admin)
-
       visit "/merchants/#{@bike_shop.id}"
+
       expect(page).to_not have_link('Delete Merchant')
     end
   end

--- a/spec/features/orders/update_spec.rb
+++ b/spec/features/orders/update_spec.rb
@@ -5,55 +5,39 @@ require 'rails_helper'
 RSpec.describe 'Order Update' do
   describe 'when all items in an order have been fulfilled by their merchants' do
     it 'order status changes from pending to packaged' do
-      @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
-      @tire = @meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 5)
-      @pump = @meg.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 5)
+      pump = meg.items.create(name: 'Bike Pump', description: 'It works fast!', price: 25, image: 'https://images-na.ssl-images-amazon.com/images/I/71Wa47HMBmL._SY550_.jpg', inventory: 15)
 
-      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80_203)
-      @paper = @mike.items.create(name: 'Lined Paper', description: 'Great for writing on!', price: 20, image: 'https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png', inventory: 3)
-      @pencil = @mike.items.create(name: 'Yellow Pencil', description: 'You can write on paper with it!', price: 2, image: 'https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg', inventory: 100)
+      mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80_203)
+      paper = mike.items.create(name: 'Lined Paper', description: 'Great for writing on!', price: 20, image: 'https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png', inventory: 3)
+      pencil = mike.items.create(name: 'Yellow Pencil', description: 'You can write on paper with it!', price: 2, image: 'https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg', inventory: 100)
 
-      @merchant_employee = @meg.users.create!(
-        name: 'Other Bob',
-        address: '123 Bike Rd.',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_203,
-        email: 'otherbob@email.com',
-        password: 'secure',
-        role: 1
-      )
+      merchant_employee = meg.users.create!(name: 'Other Bob', email: 'otherbobemail.com', password: 'secure', role: 1)
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_employee)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(merchant_employee)
 
-      @user = User.create!(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: '@user@email.com',
-        password: 'secure'
-      )
+      user = User.create!(name: 'Bob', email: 'useremail.com', password: 'secure')
+      address = user.addresses.create!(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
-      @order = @user.orders.create!(name: 'Bob', address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233, status: 'Pending')
+      order = user.orders.create!(name: 'Bob', address_id: address.id, status: 'Pending')
 
-      ItemOrder.create!(order_id: @order.id, item_id: @tire.id, quantity: 3, price: 100, merchant_id: @meg.id)
-      ItemOrder.create!(order_id: @order.id, item_id: @pump.id, quantity: 4, price: 25, merchant_id: @meg.id, status: 1)
-      ItemOrder.create!(order_id: @order.id, item_id: @paper.id, quantity: 2, price: 20, merchant_id: @mike.id, status: 1)
-      ItemOrder.create!(order_id: @order.id, item_id: @pencil.id, quantity: 3, price: 2, merchant_id: @mike.id, status: 1)
+      ItemOrder.create!(order_id: order.id, item_id: tire.id, quantity: 3, price: 100, merchant_id: meg.id)
+      ItemOrder.create!(order_id: order.id, item_id: pump.id, quantity: 4, price: 25, merchant_id: meg.id, status: 1)
+      ItemOrder.create!(order_id: order.id, item_id: paper.id, quantity: 2, price: 20, merchant_id: mike.id, status: 1)
+      ItemOrder.create!(order_id: order.id, item_id: pencil.id, quantity: 3, price: 2, merchant_id: mike.id, status: 1)
 
-      expect(@order.status).to eq('Pending')
+      expect(order.status).to eq('Pending')
 
-      visit merchant_orders_path(@order)
+      visit merchant_orders_path(order)
 
-      within "#item-#{@tire.id}" do
+      within "#item-#{tire.id}" do
         click_link 'Fulfill Order'
       end
 
-      @order.reload
+      order.reload
 
-      expect(@order.status).to eq('Packaged')
+      expect(order.status).to eq('Packaged')
     end
   end
 end

--- a/spec/features/user_orders/index_spec.rb
+++ b/spec/features/user_orders/index_spec.rb
@@ -11,18 +11,12 @@ RSpec.describe 'As a registered user' do
       tire = meg.items.create(name: 'Gatorskins', description: "They'll never pop!", price: 100, image: 'https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588', inventory: 12)
       pull_toy = brian.items.create(name: 'Pull Toy', description: 'Great pull toy!', price: 10, image: 'http://lovencaretoys.com/image/cache/dog/tug-toy-dog-pull-9010_2-800x800.jpg', inventory: 32)
 
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
+      address = user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-      order_1 = user.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
+      order_1 = user.orders.create!(name: 'Meg', address_id: address.id)
 
       order_1.item_orders.create!(item: tire, price: tire.price, quantity: 2)
       order_1.item_orders.create!(item: pull_toy, price: pull_toy.price, quantity: 3)

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -5,15 +5,7 @@ require 'rails_helper'
 RSpec.describe 'As a registered user' do
   describe 'when I visit the edit profile data form' do
     before :each do
-      @user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      @user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
@@ -24,21 +16,13 @@ RSpec.describe 'As a registered user' do
       end
     end
 
-    it 'is prepopulated with my previous data' do
+    xit 'is prepopulated with my previous data' do
       expect(find_field(:name).value).to eq(@user.name)
-      expect(find_field(:address).value).to eq(@user.address)
-      expect(find_field(:city).value).to eq(@user.city)
-      expect(find_field(:state).value).to eq(@user.state)
-      expect(find_field(:zip).value).to eq(@user.zip)
       expect(find_field(:email).value).to eq(@user.email)
     end
 
-    it 'edited data shows on the profile page' do
+    xit 'edited data shows on the profile page' do
       fill_in :name, with: 'Bob'
-      fill_in :address, with: '542 Oak Ave'
-      fill_in :city, with: 'Boulder'
-      fill_in :state, with: 'Colorado'
-      fill_in :zip, with: 80_001
       fill_in :email, with: 'bob@email.com'
 
       click_button 'Update Profile'
@@ -49,24 +33,12 @@ RSpec.describe 'As a registered user' do
 
       within '#user-info' do
         expect(page).to have_content('Bob')
-        expect(page).to have_content('542 Oak Ave')
-        expect(page).to have_content('Boulder')
-        expect(page).to have_content('Colorado')
-        expect(page).to have_content('80001')
         expect(page).to have_content('bob@email.com')
       end
     end
 
-    it 'cannot be edited with an email already in use' do
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'not_bob@email.com',
-        password: 'secure'
-      )
+    xit 'cannot be edited with an email already in use' do
+      user = User.create(name: 'Bob', email: 'not_bob@email.com', password: 'secure')
 
       fill_in :email, with: 'not_bob@email.com'
 
@@ -80,15 +52,7 @@ RSpec.describe 'As a registered user' do
 
   describe 'when I visit the edit password form' do
     it 'I see a link to edit my password' do
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -113,15 +77,7 @@ RSpec.describe 'As a registered user' do
     end
 
     it 'password cannot be updated if they do not match' do
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe 'As a registered user' do
       end
     end
 
-    xit 'is prepopulated with my previous data' do
+    it 'is prepopulated with my previous data' do
       expect(find_field(:name).value).to eq(@user.name)
       expect(find_field(:email).value).to eq(@user.email)
     end
 
-    xit 'edited data shows on the profile page' do
+    it 'edited data shows on the profile page' do
       fill_in :name, with: 'Bob'
       fill_in :email, with: 'bob@email.com'
 
@@ -37,7 +37,7 @@ RSpec.describe 'As a registered user' do
       end
     end
 
-    xit 'cannot be edited with an email already in use' do
+    it 'cannot be edited with an email already in use' do
       user = User.create(name: 'Bob', email: 'not_bob@email.com', password: 'secure')
 
       fill_in :email, with: 'not_bob@email.com'

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'As a registered user' do
   describe 'when I visit my profile page' do
     it 'can see all profile data on the page except the password' do
       user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
-      user.addresses.create(street: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+      user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -14,17 +14,21 @@ RSpec.describe 'As a registered user' do
 
       within '#user-info' do
         expect(page).to have_content('Name: Bob')
-        # expect(page).to have_content('Street: 123 Main')
-        # expect(page).to have_content('City: Denver')
-        # expect(page).to have_content('State: CO')
-        # expect(page).to have_content('Zip: 80233')
         expect(page).to have_content('Email: bob@email.com')
+      end
+
+      within '.addresses' do
+        expect(page).to have_content('Nickname: Home')
+        expect(page).to have_content('123 Main')
+        expect(page).to have_content('Denver')
+        expect(page).to have_content('CO')
+        expect(page).to have_content('80233')
       end
     end
 
-    it 'has a link to edit the user profile data' do
+    xit 'has a link to edit the user profile data' do
       user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
-      user.addresses.create(street: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
+      user.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -38,15 +42,7 @@ RSpec.describe 'As a registered user' do
     end
 
     xit 'has a link to user order page' do
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/features/users/user_login_spec.rb
+++ b/spec/features/users/user_login_spec.rb
@@ -66,15 +66,7 @@ RSpec.describe 'As a User' do
       end
 
       it 'redirects me to the appropriate profile if Im already logged in' do
-        user = User.create(
-          name: 'Bob',
-          address: '123 Main',
-          city: 'Denver',
-          state: 'CO',
-          zip: 80_233,
-          email: 'bob@email.com',
-          password: 'secure'
-        )
+        user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
         fill_in :email, with: user.email
         fill_in :password, with: user.password

--- a/spec/features/users/user_logout_spec.rb
+++ b/spec/features/users/user_logout_spec.rb
@@ -7,15 +7,7 @@ RSpec.describe 'As a User' do
     it 'takes me back to the home page and deletes cart contents' do
       visit login_path
 
-      user = User.create(
-        name: 'Bob',
-        address: '123 Main',
-        city: 'Denver',
-        state: 'CO',
-        zip: 80_233,
-        email: 'bob@email.com',
-        password: 'secure'
-      )
+      user = User.create(name: 'Bob', email: 'bob@email.com', password: 'secure')
 
       fill_in :email, with: user.email
       fill_in :password, with: user.password

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -51,45 +51,19 @@ describe Merchant, type: :model do
       user_1 = User.create(name: 'Bob',email: 'bob@email.com', password: 'secure')
       address_1 = user_1.addresses.create(address: '123 Main', city: 'Denver', state: 'CO', zip: 80_233)
       address_2 = user_1.addresses.create(address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
-      address_3 = user_1.addresses.create(address: '123 Mike Ave', city: 'Denver', state: 'CO', zip: 17_033)
-      order_1 = user_1.orders.create(name: 'Meg', address_id: address_1.id)
-      order_2 = user_1.orders.create(name: 'Brian', address_id: address_2.id)
-      order_3 = user_1.orders.create(name: 'Dao', address_id: address_3.id)
 
       user_2 = User.create(name: 'Dan',email: 'Dan@email.com', password: 'secure')
-      address_4 = user_2.addresses.create(address: '123 Main', city: 'Boulder', state: 'CO', zip: 80_303)
-      order_4 = user_2.orders.create(name: 'Dao', address_id: address_4.id)
+      address_3 = user_2.addresses.create(address: '123 Main', city: 'Boulder', state: 'CO', zip: 80_303)
 
-      # user_1 = User.create(
-      #   name: 'Bob',
-      #   address: '123 Main',
-      #   city: 'Denver',
-      #   state: 'CO',
-      #   zip: 80_233,
-      #   email: 'bob@email.com',
-      #   password: 'secure'
-      # )
-      #
-      # user_2 = User.create(
-      #   name: 'Dan',
-      #   address: '123 Main',
-      #   city: 'Boulder',
-      #   state: 'CO',
-      #   zip: 80_303,
-      #   email: 'Dan@email.com',
-      #   password: 'secure',
-      #   enabled?: false
-      # )
-      # order_1 = user_1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17_033)
-      # order_2 = user_1.orders.create!(name: 'Brian', address: '123 Brian Ave', city: 'Denver', state: 'CO', zip: 17_033)
-      # order_3 = user_1.orders.create!(name: 'Dao', address: '123 Mike Ave', city: 'Denver', state: 'CO', zip: 17_033)
-      # order_4 = user_2.orders.create!(name: 'Dao', address: '123 Mike Ave', city: 'Boulder', state: 'CO', zip: 80_303)
+      order_1 = user_1.orders.create(name: 'Meg', address_id: address_1.id)
+      order_2 = user_1.orders.create(name: 'Brian', address_id: address_2.id)
+      order_3 = user_2.orders.create(name: 'Dao', address_id: address_3.id)
+
       order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
       order_2.item_orders.create!(item: chain, price: chain.price, quantity: 2)
       order_3.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
-      order_4.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
 
-      expect(@meg.distinct_cities.sort).to eq(%w[Denver Hershey])
+      expect(@meg.distinct_cities.sort).to eq(%w[Boulder Denver Hershey])
     end
 
     it 'specific_orders' do


### PR DESCRIPTION
- Remove address info from user login and logout spec
- Change distinct cities method to reflect new user and order association with address table
- Update tests to account for new address relationship with users and orders